### PR TITLE
fix: ensure language change event emits after state update

### DIFF
--- a/src/I18n.ts
+++ b/src/I18n.ts
@@ -89,9 +89,9 @@ export class I18n<T extends Record<string, object>> extends EventEmitter<I18nEve
   }
 
   setLanguage<L extends keyof T>(language: L): void {
-    this.emit('language:changed', { language })
     this.clearCache()
     this.#language = language
+    this.emit('language:changed', { language })
   }
 
   addLanguage(language: keyof T, languageData: T[keyof T]): void {


### PR DESCRIPTION
Reorder operations in setLanguage():
- Update internal language state before emitting "language:changed"
- Clear cache prior to updating state

This ensures listeners receive the correct language value when the event fires.